### PR TITLE
Deleted the HTY icon theme after upgrading neoColor theme

### DIFF
--- a/source/forecastapplet.h
+++ b/source/forecastapplet.h
@@ -7,7 +7,7 @@
 #include "weatherclient.h"
 #include "themeset.h"
 
-#define MAXDAYS 5
+#define MAXDAYS 7
 
 class ForecastApplet : public QWidget
 {

--- a/source/res.qrc
+++ b/source/res.qrc
@@ -1,25 +1,4 @@
 <RCC>
-    <qresource prefix="/hty">
-        <file alias="na">icon/hty/na.png</file>
-        <file alias="01d">icon/hty/01d.png</file>
-        <file alias="02d">icon/hty/02d.png</file>
-        <file alias="03d">icon/hty/03d.png</file>
-        <file alias="04d">icon/hty/04d.png</file>
-        <file alias="09d">icon/hty/09d.png</file>
-        <file alias="10d">icon/hty/10d.png</file>
-        <file alias="11d">icon/hty/11d.png</file>
-        <file alias="13d">icon/hty/13d.png</file>
-        <file alias="50d">icon/hty/50d.png</file>
-        <file alias="01n">icon/hty/01n.png</file>
-        <file alias="02n">icon/hty/02n.png</file>
-        <file alias="03n">icon/hty/03n.png</file>
-        <file alias="04n">icon/hty/04n.png</file>
-        <file alias="09n">icon/hty/09n.png</file>
-        <file alias="10n">icon/hty/10n.png</file>
-        <file alias="11n">icon/hty/11n.png</file>
-        <file alias="13n">icon/hty/13n.png</file>
-        <file alias="50n">icon/hty/50n.png</file>
-    </qresource>
     <qresource prefix="/neoGray">
         <file alias="01d">icon/neoGray/01d.png</file>
         <file alias="01n">icon/neoGray/01n.png</file>

--- a/source/themeset.h
+++ b/source/themeset.h
@@ -9,6 +9,6 @@
  * In the `res.qrc` file it's expected to set alias of the icon codes:
  * `01d`, `01n`, ..., `04n`, `09d`, ..., `13d`, `13n`, `50d`, `50n`, `na`
  */
-const QStringList themeSet({"neoGray", "neoGrayS", "neoColor", "hty"});
+const QStringList themeSet({"neoGray", "neoGrayS", "neoColor"});
 
 #endif // THEMESET_H


### PR DESCRIPTION
@CareF ... i think we are ready to delete the HTY theme as discussed earlier ...

We now have

neoGrayS (Default)
neoGray
neoColor

I didn't want to directly delete from master just in case you didn't want it removed as yet ... If you are then you can go ahead and merge this PR.